### PR TITLE
fix: rotator struct reading

### DIFF
--- a/src/properties/reader.rs
+++ b/src/properties/reader.rs
@@ -560,6 +560,7 @@ impl StructPropertyParser {
             "Timespan" => StructData::Timespan(Timespan::read(reader)?),
             "DateTime" => StructData::DateTime(DateTime::read(reader)?),
             "Vector" => StructData::Vector(FVector::read(reader)?),
+            "Rotator" => StructData::Vector(FVector::read(reader)?),
             _ => StructData::Dynamic(DynamicStruct::read(reader, save_archive)?),
         };
 


### PR DESCRIPTION
it was failing due to reading  variable StartingRotation with type Rotator (same as FVector, basically)